### PR TITLE
Change from textual to non-ascii block graphic character

### DIFF
--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -3,11 +3,11 @@
 colors() {
   # if present first arg sets the number of columns
   # otherwise, the default number of columns will be 2
-  columns=${1:-"2"}
+  columns=${1:-"5"}
 
   # print out the color palette
   for i in `seq 255`; do
-    printf "\033[38;5;%dmColor %03d\t" $i $i
+    printf "\033[38;5;%dm\u2588\u2588 %03d\t" $i $i
     if (( $i % $columns == 0 )); then
       echo;
     fi;


### PR DESCRIPTION
This PR changes the colors.sh script to show color blocks instead of printing "Color" to STDIO.
This is how it looks like now when one types the command `colors 15`

![image](https://github.com/user-attachments/assets/46541499-9a6e-435a-b3c0-c6facb14c40e)


